### PR TITLE
#20: fixed issue

### DIFF
--- a/src/main/java/com/github/skapral/jersey/se/SrvGrizzlyWithJersey.java
+++ b/src/main/java/com/github/skapral/jersey/se/SrvGrizzlyWithJersey.java
@@ -105,7 +105,7 @@ public class SrvGrizzlyWithJersey implements Server {
                     apiRoot.endsWith("/") ? apiRoot + "*" : apiRoot + "/*"
                 );
             }
-            final HttpServer server = HttpServer.createSimpleServer("/", port.optionalValue().map(Integer::valueOf).get());
+            final HttpServer server = HttpServer.createSimpleServer(null, port.optionalValue().map(Integer::valueOf).get());
             final HttpHandler httpHandler = new CLStaticHttpHandler(this.getClass().getClassLoader(), "/static/");
             server.getServerConfiguration().addHttpHandler(
                 httpHandler,

--- a/src/test/java/com/github/skapral/jersey/se/SrvGrizzlyWithJerseyTest.java
+++ b/src/test/java/com/github/skapral/jersey/se/SrvGrizzlyWithJerseyTest.java
@@ -104,6 +104,54 @@ public class SrvGrizzlyWithJerseyTest extends TestsSuite {
                         "Static content"
                     )
                 )
+            ),
+            new TestCase(
+                "Server responds with default page",
+                new AssertAssumingServer(
+                    new SrvGrizzlyWithJersey(
+                        new CpStatic("20004"),
+                        new SimpleConfig(),
+                        "api",
+                        "/"
+                    ),
+                    new AssertHttpEndpointProducesExpectedResponse(
+                        () -> new HttpGet("http://localhost:20004/"),
+                        200,
+                        "<!doctype html><meta charset=utf-8><title>Hello world</title>"
+                    )
+                )
+            ),
+            new TestCase(
+                "Server responds with default page on non-root static resource",
+                new AssertAssumingServer(
+                    new SrvGrizzlyWithJersey(
+                        new CpStatic("20005"),
+                        new SimpleConfig(),
+                        "api",
+                        "/"
+                    ),
+                    new AssertHttpEndpointProducesExpectedResponse(
+                        () -> new HttpGet("http://localhost:20005/nonroot"),
+                        200,
+                        "<!doctype html><meta charset=utf-8><title>Hello world</title>"
+                    )
+                )
+            ),
+            new TestCase(
+                "Server responds with default page on non-root static context path",
+                new AssertAssumingServer(
+                    new SrvGrizzlyWithJersey(
+                        new CpStatic("20006"),
+                        new SimpleConfig(),
+                        "api",
+                        "static"
+                    ),
+                    new AssertHttpEndpointProducesExpectedResponse(
+                        () -> new HttpGet("http://localhost:20006/static/"),
+                        200,
+                        "<!doctype html><meta charset=utf-8><title>Hello world</title>"
+                    )
+                )
             )
         );
     }

--- a/src/test/resources/static/index.html
+++ b/src/test/resources/static/index.html
@@ -1,0 +1,1 @@
+<!doctype html><meta charset=utf-8><title>Hello world</title>

--- a/src/test/resources/static/nonroot/index.html
+++ b/src/test/resources/static/nonroot/index.html
@@ -1,0 +1,1 @@
+<!doctype html><meta charset=utf-8><title>Hello world</title>


### PR DESCRIPTION
Closes #20. 

Root cause: `org.glassfish.grizzly.http.server.HttpServer::createSimpleServer` initializes default `StaticHttpHandler` when `docRoot` is non-null. `StaticHttpHandler` searches for static contents on filesystem, and not the classpath.